### PR TITLE
Add NullState class for no-op state implementation

### DIFF
--- a/src/states/index.ts
+++ b/src/states/index.ts
@@ -4,5 +4,6 @@ export type { StateTransitionHandler } from './state-transition-handler.interfac
 
 export { AbstractState } from './abstract-state';
 export { CommandableState } from './commandable-state';
+export { NullState } from './null-state';
 export { SimpleState } from './simple-state';
 export { StateMachine } from './state-machine.class';

--- a/src/states/null-state.ts
+++ b/src/states/null-state.ts
@@ -1,0 +1,32 @@
+import type { State } from './state.interface';
+import type { StateMachine } from './state-machine.interface';
+
+export class NullState implements State {
+  private readonly name: string;
+
+  constructor(name?: string) {
+    this.name = name ?? 'NullState';
+  }
+
+  get stateName(): string {
+    return this.name;
+  }
+
+  get stateMachine(): StateMachine | null {
+    return null;
+  }
+  set stateMachine(_value: StateMachine | null) {}
+
+  addTransition(_transitionName: string, _toStateOrName: State | string): void {}
+  removeTransition(_transitionName: string): void {}
+  handleTransition(_transitionName: string): void {}
+
+  enterState(): void {}
+  exitState(): void {}
+  update(_dt: number): void {}
+  destroy(): void {}
+
+  static create(name?: string): State {
+    return new NullState(name);
+  }
+}

--- a/tests/null-state.test.ts
+++ b/tests/null-state.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { NullState, StateMachine } from '../src';
+
+describe('NullState', () => {
+  it('should create with default name', () => {
+    const state = NullState.create();
+    expect(state.stateName).toBe('NullState');
+  });
+
+  it('should create with custom name', () => {
+    const state = NullState.create('CustomNull');
+    expect(state.stateName).toBe('CustomNull');
+  });
+
+  it('should return null for stateMachine getter', () => {
+    const state = NullState.create();
+    expect(state.stateMachine).toBeNull();
+  });
+
+  it('should accept stateMachine setter without error', () => {
+    const state = NullState.create();
+    const sm = StateMachine.create();
+
+    expect(() => {
+      state.stateMachine = sm;
+    }).not.toThrow();
+
+    expect(state.stateMachine).toBeNull();
+
+    sm.destroy();
+  });
+
+  it('should handle all lifecycle methods without error', () => {
+    const state = NullState.create();
+
+    expect(() => {
+      state.enterState();
+      state.update(16);
+      state.exitState();
+      state.destroy();
+    }).not.toThrow();
+  });
+
+  it('should handle transition methods without error', () => {
+    const state = NullState.create();
+    const otherState = NullState.create('Other');
+
+    expect(() => {
+      state.addTransition('test', otherState);
+      state.addTransition('test2', 'SomeState');
+      state.handleTransition('test');
+      state.removeTransition('test');
+    }).not.toThrow();
+  });
+
+  it('should work as a state in StateMachine', () => {
+    const sm = StateMachine.create();
+    const nullState = NullState.create('Null');
+
+    sm.addState(nullState);
+
+    expect(() => {
+      sm.setState('Null');
+      sm.update(16);
+    }).not.toThrow();
+
+    expect(sm.currentState?.stateName).toBe('Null');
+
+    sm.destroy();
+  });
+
+  it('should not affect state machine when transitions are added', () => {
+    const sm = StateMachine.create();
+    const nullState = NullState.create('Null');
+    const otherState = NullState.create('Other');
+
+    sm.addState(nullState);
+    sm.addState(otherState);
+    sm.setState('Null');
+
+    nullState.addTransition('toOther', 'Other');
+    nullState.handleTransition('toOther');
+
+    expect(sm.currentState?.stateName).toBe('Null');
+
+    sm.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
NullState provides a placeholder/default state analogous to NullCommand. Useful for testing, initialization, and graceful fallbacks.

## Changes
- NullState class implementing State interface with no-op behavior
- Static factory method `.create(name?: string)` for instantiation
- All lifecycle and transition methods are empty implementations
- Stateless design: returns null for stateMachine getter, ignores setter
- Exported from `src/states/index.ts` for public API
- Comprehensive unit tests covering all methods and behaviors

## Test Status
- All new unit tests pass (8 test cases)
- All existing tests continue to pass
- TypeScript compilation successful

## Use Cases
- Placeholder state for initialization
- No-op state for testing purposes
- Graceful fallback when default state behavior is needed
- Analogous to existing NullCommand pattern

---
Generated with Claude Code